### PR TITLE
walkingkooka-tree/pull/204 20201102

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/number/AbsoluteNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/AbsoluteNumberExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.number;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -24,12 +25,19 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 /**
  * A abs function that expects a single {@link ExpressionNumber}.
  */
-final class AbsoluteNumberExpressionFunction extends UnaryNumberExpressionFunction {
+final class AbsoluteNumberExpressionFunction<C extends ExpressionFunctionContext> extends UnaryNumberExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> AbsoluteNumberExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final AbsoluteNumberExpressionFunction INSTANCE = new AbsoluteNumberExpressionFunction();
+    private static final AbsoluteNumberExpressionFunction INSTANCE = new AbsoluteNumberExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/number/CeilNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/CeilNumberExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.number;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -24,12 +25,19 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 /**
  * A ceil function that expects a single {@link ExpressionNumber}.
  */
-final class CeilNumberExpressionFunction extends UnaryNumberExpressionFunction {
+final class CeilNumberExpressionFunction<C extends ExpressionFunctionContext> extends UnaryNumberExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> CeilNumberExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final CeilNumberExpressionFunction INSTANCE = new CeilNumberExpressionFunction();
+    private static final CeilNumberExpressionFunction INSTANCE = new CeilNumberExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/number/CountNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/CountNumberExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.number;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -26,12 +27,19 @@ import java.util.List;
 /**
  * Counts the number of parameters given to this function.
  */
-final class CountNumberExpressionFunction extends NumberExpressionFunction<ExpressionNumber> {
+final class CountNumberExpressionFunction<C extends ExpressionFunctionContext> extends NumberExpressionFunction<ExpressionNumber, C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> CountNumberExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final CountNumberExpressionFunction INSTANCE = new CountNumberExpressionFunction();
+    private static final CountNumberExpressionFunction INSTANCE = new CountNumberExpressionFunction();
 
     private CountNumberExpressionFunction() {
         super();
@@ -39,7 +47,7 @@ final class CountNumberExpressionFunction extends NumberExpressionFunction<Expre
 
     @Override
     public ExpressionNumber apply(final List<Object> parameters,
-                                  final ExpressionFunctionContext context) {
+                                  final C context) {
         return context.expressionNumberKind().create(parameters.size());
     }
 

--- a/src/main/java/walkingkooka/tree/expression/function/number/FloorNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/FloorNumberExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.number;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -25,12 +26,19 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 /**
  * A floor function that expects a single {@link ExpressionNumber}.
  */
-final class FloorNumberExpressionFunction extends UnaryNumberExpressionFunction {
+final class FloorNumberExpressionFunction<C extends ExpressionFunctionContext> extends UnaryNumberExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> FloorNumberExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final FloorNumberExpressionFunction INSTANCE = new FloorNumberExpressionFunction();
+    private static final FloorNumberExpressionFunction INSTANCE = new FloorNumberExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/number/NumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/NumberExpressionFunction.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Base for any function that handles and requires numbers.
  */
-abstract class NumberExpressionFunction<T> implements ExpressionFunction<T> {
+abstract class NumberExpressionFunction<T, C extends ExpressionFunctionContext> implements ExpressionFunction<T, C> {
 
     /**
      * Package private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/number/NumberExpressionFunctions.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/NumberExpressionFunctions.java
@@ -21,6 +21,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import java.util.function.Consumer;
 
@@ -32,7 +33,7 @@ public final class NumberExpressionFunctions implements PublicStaticHelper {
     /**
      * Visit all {@link ExpressionFunction functions}.
      */
-    public static void visit(final Consumer<ExpressionFunction<?>> consumer) {
+    public static void visit(final Consumer<ExpressionFunction<?, ?>> consumer) {
         Lists.of(abs(),
                 ceil(),
                 count(),
@@ -45,43 +46,43 @@ public final class NumberExpressionFunctions implements PublicStaticHelper {
     /**
      * {@see AbsoluteNumberExpressionFunction}
      */
-    public static ExpressionFunction<ExpressionNumber> abs() {
-        return AbsoluteNumberExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<ExpressionNumber, C> abs() {
+        return AbsoluteNumberExpressionFunction.instance();
     }
 
     /**
      * {@see CeilNumberExpressionFunction}
      */
-    public static ExpressionFunction<ExpressionNumber> ceil() {
-        return CeilNumberExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<ExpressionNumber, C> ceil() {
+        return CeilNumberExpressionFunction.instance();
     }
 
     /**
      * {@see CountNumberExpressionFunction}
      */
-    public static ExpressionFunction<ExpressionNumber> count() {
-        return CountNumberExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<ExpressionNumber, C> count() {
+        return CountNumberExpressionFunction.instance();
     }
 
     /**
      * {@see FloorNumberExpressionFunction}
      */
-    public static ExpressionFunction<ExpressionNumber> floor() {
-        return FloorNumberExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<ExpressionNumber, C> floor() {
+        return FloorNumberExpressionFunction.instance();
     }
 
     /**
      * {@see NumberExpressionFunction}
      */
-    public static ExpressionFunction<ExpressionNumber> number() {
-        return ToNumberExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<ExpressionNumber, C> number() {
+        return ToNumberExpressionFunction.instance();
     }
 
     /**
      * {@see RoundNumberExpressionFunction}
      */
-    public static ExpressionFunction<ExpressionNumber> round() {
-        return RoundNumberExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<ExpressionNumber, C> round() {
+        return RoundNumberExpressionFunction.instance();
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/function/number/RoundNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/RoundNumberExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.number;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -24,12 +25,19 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 /**
  * A round function that expects a single {@link ExpressionNumber}.
  */
-final class RoundNumberExpressionFunction extends UnaryNumberExpressionFunction {
+final class RoundNumberExpressionFunction<C extends ExpressionFunctionContext> extends UnaryNumberExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> RoundNumberExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final RoundNumberExpressionFunction INSTANCE = new RoundNumberExpressionFunction();
+    private static final RoundNumberExpressionFunction INSTANCE = new RoundNumberExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/number/ToNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/ToNumberExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.number;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
@@ -25,12 +26,19 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 /**
  * A {@link ExpressionFunction} that performs some operation and returns a {@link ExpressionNumber}.
  */
-final class ToNumberExpressionFunction extends UnaryNumberExpressionFunction {
+final class ToNumberExpressionFunction<C extends ExpressionFunctionContext> extends UnaryNumberExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> ToNumberExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final ToNumberExpressionFunction INSTANCE = new ToNumberExpressionFunction();
+    private static final ToNumberExpressionFunction INSTANCE = new ToNumberExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/number/UnaryNumberExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/number/UnaryNumberExpressionFunction.java
@@ -22,7 +22,7 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import java.util.List;
 
-abstract class UnaryNumberExpressionFunction extends NumberExpressionFunction<ExpressionNumber> {
+abstract class UnaryNumberExpressionFunction<C extends ExpressionFunctionContext> extends NumberExpressionFunction<ExpressionNumber, C> {
 
     /**
      * Package private ctor
@@ -33,7 +33,7 @@ abstract class UnaryNumberExpressionFunction extends NumberExpressionFunction<Ex
 
     @Override
     public final ExpressionNumber apply(final List<Object> parameters,
-                                        final ExpressionFunctionContext context) {
+                                        final C context) {
         this.checkParameterCount(parameters, 1);
         return applyExpressionNumber(this.expressionNumber(parameters, 0, context), context);
     }

--- a/src/test/java/walkingkooka/tree/expression/function/number/AbsoluteNumberExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/AbsoluteNumberExpressionFunctionTest.java
@@ -18,8 +18,10 @@
 package walkingkooka.tree.expression.function.number;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class AbsoluteNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<AbsoluteNumberExpressionFunction> {
+public final class AbsoluteNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<AbsoluteNumberExpressionFunction<ExpressionFunctionContext>> {
 
     // Double...........................................................................................................
 
@@ -65,13 +67,13 @@ public final class AbsoluteNumberExpressionFunctionTest extends UnaryNumberExpre
     // helper...........................................................................................................
 
     @Override
-    public AbsoluteNumberExpressionFunction createBiFunction() {
-        return AbsoluteNumberExpressionFunction.INSTANCE;
+    public AbsoluteNumberExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return AbsoluteNumberExpressionFunction.instance();
     }
 
     @Override
-    public Class<AbsoluteNumberExpressionFunction> type() {
-        return AbsoluteNumberExpressionFunction.class;
+    public Class<AbsoluteNumberExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(AbsoluteNumberExpressionFunction.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/number/CeilNumberExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/CeilNumberExpressionFunctionTest.java
@@ -18,8 +18,10 @@
 package walkingkooka.tree.expression.function.number;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class CeilNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<CeilNumberExpressionFunction> {
+public final class CeilNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<CeilNumberExpressionFunction<ExpressionFunctionContext>> {
 
     // Double........................................................................................................
 
@@ -41,13 +43,13 @@ public final class CeilNumberExpressionFunctionTest extends UnaryNumberExpressio
     // helper...........................................................................................................
 
     @Override
-    public CeilNumberExpressionFunction createBiFunction() {
-        return CeilNumberExpressionFunction.INSTANCE;
+    public CeilNumberExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return CeilNumberExpressionFunction.instance();
     }
 
     @Override
-    public Class<CeilNumberExpressionFunction> type() {
-        return CeilNumberExpressionFunction.class;
+    public Class<CeilNumberExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(CeilNumberExpressionFunction.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/number/CountNumberExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/CountNumberExpressionFunctionTest.java
@@ -18,15 +18,15 @@
 package walkingkooka.tree.expression.function.number;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
-import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
 
 import java.util.Collections;
 
-public final class CountNumberExpressionFunctionTest extends NumberExpressionFunctionTestCase<CountNumberExpressionFunction, ExpressionNumber> {
+public final class CountNumberExpressionFunctionTest extends NumberExpressionFunctionTestCase<CountNumberExpressionFunction<ExpressionFunctionContext>, ExpressionNumber> {
 
     private final static ExpressionNumberKind KIND = ExpressionNumberKind.DEFAULT;
 
@@ -47,26 +47,16 @@ public final class CountNumberExpressionFunctionTest extends NumberExpressionFun
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(CountNumberExpressionFunction.INSTANCE, "count");
+        this.toStringAndCheck(this.createBiFunction(), "count");
     }
 
     @Override
-    public CountNumberExpressionFunction createBiFunction() {
-        return CountNumberExpressionFunction.INSTANCE;
+    public CountNumberExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return CountNumberExpressionFunction.instance();
     }
 
     @Override
-    public ExpressionFunctionContext createContext() {
-        return new FakeExpressionFunctionContext() {
-            @Override
-            public ExpressionNumberKind expressionNumberKind() {
-                return KIND;
-            }
-        };
-    }
-
-    @Override
-    public Class<CountNumberExpressionFunction> type() {
-        return CountNumberExpressionFunction.class;
+    public Class<CountNumberExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(CountNumberExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/number/FloorNumberExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/FloorNumberExpressionFunctionTest.java
@@ -18,8 +18,10 @@
 package walkingkooka.tree.expression.function.number;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class FloorNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<FloorNumberExpressionFunction> {
+public final class FloorNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<FloorNumberExpressionFunction<ExpressionFunctionContext>> {
 
     // Double...........................................................................................................
 
@@ -55,13 +57,13 @@ public final class FloorNumberExpressionFunctionTest extends UnaryNumberExpressi
     // helper...........................................................................................................
 
     @Override
-    public FloorNumberExpressionFunction createBiFunction() {
-        return FloorNumberExpressionFunction.INSTANCE;
+    public FloorNumberExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return FloorNumberExpressionFunction.instance();
     }
 
     @Override
-    public Class<FloorNumberExpressionFunction> type() {
-        return FloorNumberExpressionFunction.class;
+    public Class<FloorNumberExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(FloorNumberExpressionFunction.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/number/NumberExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/NumberExpressionFunctionTestCase.java
@@ -17,16 +17,60 @@
 
 package walkingkooka.tree.expression.function.number;
 
+import walkingkooka.Either;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 import walkingkooka.tree.expression.function.ExpressionFunctionTesting;
+import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
 
-public abstract class NumberExpressionFunctionTestCase<F extends ExpressionFunction<T>, T> implements ExpressionFunctionTesting<F, T>,
+import java.math.BigDecimal;
+import java.util.List;
+
+public abstract class NumberExpressionFunctionTestCase<F extends ExpressionFunction<T, ExpressionFunctionContext>, T> implements ExpressionFunctionTesting<F, T, ExpressionFunctionContext>,
         ClassTesting2<F> {
+
+    final static ExpressionNumberKind KIND = ExpressionNumberKind.DEFAULT;
 
     NumberExpressionFunctionTestCase() {
         super();
+    }
+
+    final void apply2(final Object... parameters) {
+        this.createBiFunction().apply(parameters(parameters), this.createContext());
+    }
+
+    final void applyAndCheck2(final List<Object> parameters,
+                              final T result) {
+        this.applyAndCheck2(this.createBiFunction(), parameters, result);
+    }
+
+    final void applyAndCheck2(final ExpressionFunction<T, ExpressionFunctionContext> function,
+                              final List<Object> parameters,
+                              final T result) {
+        this.applyAndCheck2(function, parameters, this.createContext(), result);
+    }
+
+    @Override
+    public ExpressionFunctionContext createContext() {
+        return new FakeExpressionFunctionContext() {
+            @Override
+            public ExpressionNumberKind expressionNumberKind() {
+                return KIND;
+            }
+
+            @Override
+            public <T> Either<T, String> convert(final Object value,
+                                                 final Class<T> target) {
+
+                final Number number = value instanceof String ?
+                        new BigDecimal((String) value) :
+                        (Number) value;
+                return Either.left(target.cast(KIND.create(number)));
+            }
+        };
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/number/RoundNumberExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/RoundNumberExpressionFunctionTest.java
@@ -18,8 +18,10 @@
 package walkingkooka.tree.expression.function.number;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class RoundNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<RoundNumberExpressionFunction> {
+public final class RoundNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<RoundNumberExpressionFunction<ExpressionFunctionContext>> {
 
     // Double...........................................................................................................
 
@@ -50,13 +52,13 @@ public final class RoundNumberExpressionFunctionTest extends UnaryNumberExpressi
     // helper............................................................................................................
 
     @Override
-    public RoundNumberExpressionFunction createBiFunction() {
-        return RoundNumberExpressionFunction.INSTANCE;
+    public RoundNumberExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return RoundNumberExpressionFunction.instance();
     }
 
     @Override
-    public Class<RoundNumberExpressionFunction> type() {
-        return RoundNumberExpressionFunction.class;
+    public Class<RoundNumberExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(RoundNumberExpressionFunction.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/number/ToNumberExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/ToNumberExpressionFunctionTest.java
@@ -18,10 +18,12 @@
 package walkingkooka.tree.expression.function.number;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class ToNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<ToNumberExpressionFunction> {
+public final class ToNumberExpressionFunctionTest extends UnaryNumberExpressionFunctionTestCase<ToNumberExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testZeroParametersFails() {
@@ -54,12 +56,12 @@ public final class ToNumberExpressionFunctionTest extends UnaryNumberExpressionF
     }
 
     @Override
-    public ToNumberExpressionFunction createBiFunction() {
-        return ToNumberExpressionFunction.INSTANCE;
+    public ToNumberExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return ToNumberExpressionFunction.instance();
     }
 
     @Override
-    public Class<ToNumberExpressionFunction> type() {
-        return ToNumberExpressionFunction.class;
+    public Class<ToNumberExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(ToNumberExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/number/UnaryNumberExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/number/UnaryNumberExpressionFunctionTestCase.java
@@ -21,16 +21,14 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.tree.expression.ExpressionNumber;
-import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class UnaryNumberExpressionFunctionTestCase<F extends UnaryNumberExpressionFunction> extends NumberExpressionFunctionTestCase<F, ExpressionNumber> {
-
-    final static ExpressionNumberKind KIND = ExpressionNumberKind.DEFAULT;
+public abstract class UnaryNumberExpressionFunctionTestCase<F extends UnaryNumberExpressionFunction<ExpressionFunctionContext>> extends NumberExpressionFunctionTestCase<F, ExpressionNumber> {
 
     UnaryNumberExpressionFunctionTestCase() {
         super();


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka-tree/pull/204
- ExpressionFunction ExpressionFunctionContext type parameter

- NodeSelectorContext removed convert, function methods.
- BasicNodeSelectorContext removed Converter, ConverterContext, Function functions replaced with Function<NodeSelectorContext, ExpressionEvaluationContext>
- Introduced NodeSelectorExpressionFunctionContext
- Added NodeExpressionFunction

- https://github.com/mP1/walkingkooka-tree/issues/201
- NodeExpressionFunction returns current Node by querying NodeExpressionFunctionContext.node()

- https://github.com/mP1/walkingkooka-tree/issues/200
- NodeSelectorExpressionFunctionContext extends ExpressionFunctionContext

- https://github.com/mP1/walkingkooka-tree/issues/193
- NodeSelectorContext need a better way to share current Node with expressions